### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a simple MCP server that provides tools to scrape websites and extract structured data using Firecrawl's APIs.
 
+<a href="https://glama.ai/mcp/servers/sftk6d22mq">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/sftk6d22mq/badge" alt="Firecrawl Server MCP server" />
+</a>
+
 ## Setup
 
 1. Install dependencies:
@@ -117,4 +121,4 @@ If you encounter issues:
 1. Verify your Firecrawl API token is valid
 2. Check that the URLs you're trying to scrape are accessible
 3. For complex schemas, ensure they follow the supported format
-4. Review Sentry logs for detailed error information (if configured) 
+4. Review Sentry logs for detailed error information (if configured)


### PR DESCRIPTION
This PR adds a badge for the [MCP Firecrawl Server](https://glama.ai/mcp/servers/sftk6d22mq) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/sftk6d22mq">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/sftk6d22mq/badge" alt="Firecrawl Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.